### PR TITLE
Update Lab to TensorFlow 0.12

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,7 +1,7 @@
 name: CarND-TensorFlow-Lab
 dependencies:
 - openssl=1.0.2j
-- pip=8.1.2
+- pip>=8.1.2
 - psutil=4.4.1
 - python>=3.4.0
 - readline=6.2
@@ -50,6 +50,7 @@ dependencies:
   - simplegeneric==0.8.1
   - six==1.10.0
   - sklearn==0.0
+  - tensorflow>=0.12.0rc1
   - terminado==0.6
   - tornado==4.4.2
   - tqdm==4.8.4

--- a/lab.ipynb
+++ b/lab.ipynb
@@ -399,7 +399,7 @@
     "loss = tf.reduce_mean(cross_entropy)\n",
     "\n",
     "# Create an operation that initializes all variables\n",
-    "init = tf.initialize_all_variables()\n",
+    "init = tf.global_variables_initializer()\n",
     "\n",
     "# Test Cases\n",
     "with tf.Session() as session:\n",
@@ -625,9 +625,9 @@
  "metadata": {
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python [CarND-TensorFlow-Lab]",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "Python [CarND-TensorFlow-Lab]"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {


### PR DESCRIPTION
I updated the environment file and the variable initializer function.

Once we merge this change, the TensorFlow installation will happen from within the environment.yml file, so we should remove from the lab instructions the separate command to install the tensorflow package:

`$ conda install --name CarND-TensorFlow-Lab -c conda-forge tensorflow`