### PR TITLE
fixed an ENV issue in the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN curl -O https://bootstrap.pypa.io/get-pip.py && \
 
 ADD https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh tmp/Miniconda3-latest-Linux-x86_64.sh
 RUN bash tmp/Miniconda3-latest-Linux-x86_64.sh -b
-ENV PATH $PATH:/root/miniconda3/bin/
+ENV PATH /root/miniconda3/bin:$PATH
 COPY environment.yml  .
 RUN conda install --yes pyyaml
 RUN conda env create -f environment.yml


### PR DESCRIPTION
changed $PATH:/root/miniconda3/bin/ to /root/miniconda3/bin:$PATH as otherwise any existing version of python overtakes the newly installed miniconda one