### PR TITLE
reduction_indices renamed to axis

### DIFF
--- a/lab.ipynb
+++ b/lab.ipynb
@@ -27,9 +27,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import hashlib\n",
@@ -58,9 +56,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "def download(url, file):\n",
@@ -91,9 +87,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "def uncompress_features_labels(file):\n",
@@ -165,9 +159,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Problem 1 - Implement Min-Max scaling for grayscale image data\n",
@@ -203,9 +195,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "if not is_labels_encod:\n",
@@ -226,9 +216,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "assert is_features_normal, 'You skipped the step to normalize the features'\n",
@@ -247,9 +235,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Save the data for easy access\n",
@@ -286,9 +272,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "%matplotlib inline\n",
@@ -342,9 +326,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "features_count = 784\n",
@@ -393,7 +375,7 @@
     "prediction = tf.nn.softmax(logits)\n",
     "\n",
     "# Cross entropy\n",
-    "cross_entropy = -tf.reduce_sum(labels * tf.log(prediction), reduction_indices=1)\n",
+    "cross_entropy = -tf.reduce_sum(labels * tf.log(prediction), axis=1)\n",
     "\n",
     "# Training loss\n",
     "loss = tf.reduce_mean(cross_entropy)\n",
@@ -417,9 +399,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Determine if the predictions are correct\n",
@@ -478,9 +458,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# TODO: Find the best parameters for each configuration\n",
@@ -569,9 +547,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# TODO: Set the epochs, batch_size, and learning_rate with the best parameters from problem 3\n",
@@ -639,9 +615,13 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.2"
+   "version": "3.5.3"
+  },
+  "widgets": {
+   "state": {},
+   "version": "1.1.2"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }


### PR DESCRIPTION
This is just one change for tf v.1, but it looks like some metadata stuff got changed as well. Let me know if that's a problem and you want me to get the two files aligned 100%. 

I was also using the latest python 3.5 version figuring I'd use that in the carnd starter kit. Probably shouldn't accept this anyway until cardnd starter kit is changed.